### PR TITLE
Updated code for newer version of prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,4 @@
     "printWidth": 80,
     "tabWidth": 4,
     "semi": true,
-    "parser": "babylon"
 }

--- a/index.js
+++ b/index.js
@@ -5,14 +5,14 @@ const constFile = require('./src/const');
 mkdirp.sync(constFile.cacheDir);
 
 const PRETTIER_ASSET_EXTENSIONS = {
-    Html:["html"],
-    Js:["js","jsx","ts","tsx"],
-    Css:["css"],
-    Less:["less"],
-    Sass:["scss"],
-    Json:["json"],
-    Graphql:["graphql"]
-}
+    Html: ["html"],
+    Js: ["js", "jsx", "ts", "tsx"],
+    Css: ["css"],
+    Less: ["less"],
+    Sass: ["scss"],
+    Json: ["json"],
+    Graphql: ["graphql"]
+};
 
 module.exports = function (bundler) {
     jsonfile.writeFileSync(constFile.cacheFile, {});
@@ -25,7 +25,7 @@ module.exports = function (bundler) {
 
     bundler.on('bundled', () => {
         let cache;
-        cache={};
+        cache = {};
         try {
             cache = jsonfile.readFileSync(constFile.cacheFile);
         } catch (e) {
@@ -38,7 +38,7 @@ module.exports = function (bundler) {
         cache.log.forEach(element => {
             bundler.logger.write(element);
         });
-        
+
         jsonfile.writeFileSync(constFile.cacheFile, {});
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parcel-plugin-prettier",
   "version": "0.0.4",
-  "description": "Parcel plugin to add Prettier to your code r",
+  "description": "Parcel plugin to add Prettier to your code",
   "main": "index.js",
   "scripts": {
     "test": "rm -rf .cache && rm -rf dist && node test/index.js"
@@ -11,13 +11,14 @@
   "dependencies": {
     "jsonfile": "^4.0.0",
     "mkdirp": "^0.5.1",
-    "prettier": "^1.10.2"
+    "prettier": "^1.15.3"
   },
   "peerDependencies": {
-    "prettier": "^1.10.2",
-    "parcel-bundler": "^1.6.2"
+    "prettier": "^1.15.3",
+    "parcel-bundler": "^1.11"
   },
   "devDependencies": {
-    "parcel-bundler": "^1.6.2"
+    "prettier": "^1.15.3",
+    "parcel-bundler": "^1.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-prettier",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Parcel plugin to add Prettier to your code",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-prettier",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Parcel plugin to add Prettier to your code",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-prettier",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Parcel plugin to add Prettier to your code",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-prettier",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Parcel plugin to add Prettier to your code",
   "main": "index.js",
   "scripts": {

--- a/src/AssetCss.js
+++ b/src/AssetCss.js
@@ -1,16 +1,16 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const CSSAsset = require('parcel-bundler/src/assets/CSSAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetCss extends CSSAsset {
     async load() {
         
         let code = await super.load();
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
-        var config = Object.assign({},await prettier.resolveConfig(this.name),{parser: "css"});
+        var config = Object.assign({},await prettier.resolveConfig(this.name));
+
+        config.filepath = this.name;
         
         var prettierSource = prettier.format(
             code,

--- a/src/AssetCss.js
+++ b/src/AssetCss.js
@@ -1,32 +1,10 @@
-const prettier = require("prettier");
-const CSSAsset = require('parcel-bundler/src/assets/CSSAsset');
+const transformFiles = require('./common');
+const CSSAsset = require('parcel-bundler/src/Assets/CSSAsset');
 
-const { writeFile } = require('fs');
-
-class AssetCss extends CSSAsset {
-    async load() {
-        
-        let code = await super.load();
-        this.encoding = 'utf-8';
-        var config = Object.assign({},await prettier.resolveConfig(this.name));
-
-        config.filepath = this.name;
-        
-        var prettierSource = prettier.format(
-            code,
-            config
-        );
-        if (prettierSource !== code ) {
-            new Promise((resolve, reject) => {
-                writeFile(this.name, prettierSource, this.encoding, err => {
-                if (err) throw err;
-                });
-            })
-        }
-        
-        return code;
+class PrettyAsset extends CSSAsset {
+    async transform() {
+        transformFiles(this);
     }
-    getParserOptions(){}
 }
 
-module.exports = AssetCss;
+module.exports = PrettyAsset;

--- a/src/AssetGraphql.js
+++ b/src/AssetGraphql.js
@@ -1,8 +1,7 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const GraphqlAsset = require('parcel-bundler/src/assets/GraphqlAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetGraphql extends GraphqlAsset {
     async load() {
@@ -10,8 +9,9 @@ class AssetGraphql extends GraphqlAsset {
         let code = await super.load();
 
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
-        var config = Object.assign({},await prettier.resolveConfig(this.name),{parser: "graphql"});
+        var config = Object.assign({},await prettier.resolveConfig(this.name));
+
+        config.filepath = this.name;
         
         var prettierSource = prettier.format(
             code,

--- a/src/AssetGraphql.js
+++ b/src/AssetGraphql.js
@@ -1,33 +1,10 @@
-const prettier = require("prettier");
-const GraphqlAsset = require('parcel-bundler/src/assets/GraphqlAsset');
+const transformFiles = require('./common');
+const GraphqlAsset = require('parcel-bundler/src/Assets/GraphqlAsset');
 
-const { writeFile } = require('fs');
-
-class AssetGraphql extends GraphqlAsset {
-    async load() {
-        
-        let code = await super.load();
-
-        this.encoding = 'utf-8';
-        var config = Object.assign({},await prettier.resolveConfig(this.name));
-
-        config.filepath = this.name;
-        
-        var prettierSource = prettier.format(
-            code,
-            config
-        );
-        if (prettierSource !== code ) {
-            new Promise((resolve, reject) => {
-                writeFile(this.name, prettierSource, this.encoding, err => {
-                if (err) throw err;
-                });
-            })
-        }
-        
-        return code;
+class PrettyAsset extends GraphqlAsset {
+    async transform() {
+        transformFiles(this);
     }
-    getParserOptions(){}
 }
 
-module.exports = AssetGraphql;
+module.exports = PrettyAsset;

--- a/src/AssetHtml.js
+++ b/src/AssetHtml.js
@@ -1,32 +1,10 @@
-const prettier = require("prettier");
-const HTMLAsset = require('parcel-bundler/src/assets/HTMLAsset');
+const transformFiles = require('./common');
+const HTMLAsset = require('parcel-bundler/src/Assets/HTMLAsset');
 
-const { writeFile } = require('fs');
-
-class AssetHtml extends HTMLAsset {
-    async load() {
-        
-        let code = await super.load();
-
-        this.encoding = 'utf-8';
-        var config = Object.assign({}, prettier.resolveConfig.sync(this.name));
-
-        config.filepath = this.name;
-        
-        var prettierSource = prettier.format(
-            code,
-            config
-        );
-        if (prettierSource !== code ) {
-            new Promise((resolve, reject) => {
-                writeFile(this.name, prettierSource, this.encoding, err => {
-                if (err) throw err;
-                });
-            })
-        }
-        
-        return code;
+class PrettyAsset extends HTMLAsset {
+    async transform() {
+        transformFiles(this);
     }
 }
 
-module.exports = AssetHtml;
+module.exports = PrettyAsset;

--- a/src/AssetHtml.js
+++ b/src/AssetHtml.js
@@ -1,8 +1,7 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const HTMLAsset = require('parcel-bundler/src/assets/HTMLAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetHtml extends HTMLAsset {
     async load() {
@@ -10,8 +9,9 @@ class AssetHtml extends HTMLAsset {
         let code = await super.load();
 
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
-        var config = Object.assign({},await prettier.resolveConfig(this.name),{parser: "parse5"});
+        var config = Object.assign({}, prettier.resolveConfig.sync(this.name));
+
+        config.filepath = this.name;
         
         var prettierSource = prettier.format(
             code,
@@ -27,7 +27,6 @@ class AssetHtml extends HTMLAsset {
         
         return code;
     }
-    getParserOptions(){}
 }
 
 module.exports = AssetHtml;

--- a/src/AssetJs.js
+++ b/src/AssetJs.js
@@ -1,33 +1,10 @@
-const prettier = require("prettier");
-const JSAsset = require('parcel-bundler/src/assets/JSAsset');
+const transformFiles = require('./common');
+const JSAsset = require('parcel-bundler/src/Assets/JSAsset');
 
-const { writeFile } = require('fs');
-
-class AssetJs extends JSAsset {
-    async load() {
-        
-        let code = await super.load();
-
-        this.encoding = 'utf-8';
-        var config = Object.assign({},await prettier.resolveConfig(this.name));
-
-        config.filepath = this.name;
-        
-        var prettierSource = prettier.format(
-            code,
-            config
-        );
-        if (prettierSource !== code ) {
-            new Promise((resolve, reject) => {
-                writeFile(this.name, prettierSource, this.encoding, err => {
-                if (err) throw err;
-                });
-            })
-        }
-        
-        return code;
+class PrettyAsset extends JSAsset {
+    async transform() {
+        transformFiles(this);
     }
-    getParserOptions(){}
 }
 
-module.exports = AssetJs;
+module.exports = PrettyAsset;

--- a/src/AssetJs.js
+++ b/src/AssetJs.js
@@ -1,8 +1,7 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const JSAsset = require('parcel-bundler/src/assets/JSAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetJs extends JSAsset {
     async load() {
@@ -10,8 +9,9 @@ class AssetJs extends JSAsset {
         let code = await super.load();
 
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
         var config = Object.assign({},await prettier.resolveConfig(this.name));
+
+        config.filepath = this.name;
         
         var prettierSource = prettier.format(
             code,

--- a/src/AssetJson.js
+++ b/src/AssetJson.js
@@ -1,33 +1,10 @@
-const prettier = require("prettier");
-const JSONAsset = require('parcel-bundler/src/assets/JSONAsset');
+const transformFiles = require('./common');
+const JSONAsset = require('parcel-bundler/src/Assets/JSONAsset');
 
-const { writeFile } = require('fs');
-
-class AssetJson extends JSONAsset {
-    async load() {
-        
-        let code = await super.load();
-
-        this.encoding = 'utf-8';
-        var config = Object.assign({},await prettier.resolveConfig(this.name));
-        
-        config.filepath = this.name;
-        
-        var prettierSource = prettier.format(
-            code,
-            config
-        );
-        if (prettierSource !== code ) {
-            new Promise((resolve, reject) => {
-                writeFile(this.name, prettierSource, this.encoding, err => {
-                if (err) throw err;
-                });
-            })
-        }
-        
-        return code;
+class PrettyAsset extends JSAsset {
+    async transform() {
+        transformFiles(this);
     }
-    getParserOptions(){}
 }
 
-module.exports = AssetJson;
+module.exports = PrettyAsset;

--- a/src/AssetJson.js
+++ b/src/AssetJson.js
@@ -1,8 +1,7 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const JSONAsset = require('parcel-bundler/src/assets/JSONAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetJson extends JSONAsset {
     async load() {
@@ -10,9 +9,10 @@ class AssetJson extends JSONAsset {
         let code = await super.load();
 
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
-        var config = Object.assign({},await prettier.resolveConfig(this.name),{parser: "json"});
-        console.log(config);
+        var config = Object.assign({},await prettier.resolveConfig(this.name));
+        
+        config.filepath = this.name;
+        
         var prettierSource = prettier.format(
             code,
             config

--- a/src/AssetLess.js
+++ b/src/AssetLess.js
@@ -1,33 +1,10 @@
-const prettier = require("prettier");
-const LESSAsset = require('parcel-bundler/src/assets/LESSAsset');
+const transformFiles = require('./common');
+const LessASSET = require('parcel-bundler/src/Assets/LESSAsset');
 
-const { writeFile } = require('fs');
-
-class AssetLess extends LESSAsset {
-    async load() {
-        
-        let code = await super.load();
-
-        this.encoding = 'utf-8';
-        var config = Object.assign({},await prettier.resolveConfig(this.name));
-
-        config.filepath = this.name;
-        
-        var prettierSource = prettier.format(
-            code,
-            config
-        );
-        if (prettierSource !== code ) {
-            new Promise((resolve, reject) => {
-                writeFile(this.name, prettierSource, this.encoding, err => {
-                if (err) throw err;
-                });
-            })
-        }
-        
-        return code;
+class PrettyAsset extends LessASSET {
+    async transform() {
+        transformFiles(this);
     }
-    getParserOptions(){}
 }
 
-module.exports = AssetLess;
+module.exports = PrettyAsset;

--- a/src/AssetLess.js
+++ b/src/AssetLess.js
@@ -1,8 +1,7 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const LESSAsset = require('parcel-bundler/src/assets/LESSAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetLess extends LESSAsset {
     async load() {
@@ -10,8 +9,9 @@ class AssetLess extends LESSAsset {
         let code = await super.load();
 
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
-        var config = Object.assign({},await prettier.resolveConfig(this.name),{parser: "less"});
+        var config = Object.assign({},await prettier.resolveConfig(this.name));
+
+        config.filepath = this.name;
         
         var prettierSource = prettier.format(
             code,

--- a/src/AssetMd.js
+++ b/src/AssetMd.js
@@ -1,8 +1,7 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const JSAsset = require('parcel-bundler/src/assets/JSAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetJs extends JSAsset {
     async load() {
@@ -10,8 +9,9 @@ class AssetJs extends JSAsset {
         let code = await super.load();
 
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
         var config = Object.assign({},await prettier.resolveConfig(this.name));
+
+        config.filepath = this.name;
         
         var prettierSource = prettier.format(
             code,

--- a/src/AssetSass.js
+++ b/src/AssetSass.js
@@ -1,33 +1,10 @@
-const prettier = require("prettier");
-const SASSAsset = require('parcel-bundler/src/assets/SASSAsset');
+const transformFiles = require('./common');
+const SASSAsset = require('parcel-bundler/src/Assets/SASSAsset');
 
-const { writeFile } = require('fs');
-
-class AssetSass extends SASSAsset {
-    async load() {
-        
-        let code = await super.load();
-
-        this.encoding = 'utf-8';
-        var config = Object.assign({},await prettier.resolveConfig(this.name));
-
-        config.filepath = this.name;
-        
-        var prettierSource = prettier.format(
-            code,
-            config
-        );
-        if (prettierSource !== code ) {
-            new Promise((resolve, reject) => {
-                writeFile(this.name, prettierSource, this.encoding, err => {
-                if (err) throw err;
-                });
-            })
-        }
-        
-        return code;
+class PrettyAsset extends SASSAsset {
+    async transform() {
+        transformFiles(this);
     }
-    getParserOptions(){}
 }
 
-module.exports = AssetSass;
+module.exports = PrettyAsset;

--- a/src/AssetSass.js
+++ b/src/AssetSass.js
@@ -1,8 +1,7 @@
 const prettier = require("prettier");
-const { Asset } = require('parcel-bundler');
 const SASSAsset = require('parcel-bundler/src/assets/SASSAsset');
 
-const { writeFile, readFileSync } = require('fs');
+const { writeFile } = require('fs');
 
 class AssetSass extends SASSAsset {
     async load() {
@@ -10,8 +9,9 @@ class AssetSass extends SASSAsset {
         let code = await super.load();
 
         this.encoding = 'utf-8';
-        const file = readFileSync(this.name, this.encoding );
-        var config = Object.assign({},await prettier.resolveConfig(this.name),{parser: "scss"});
+        var config = Object.assign({},await prettier.resolveConfig(this.name));
+
+        config.filepath = this.name;
         
         var prettierSource = prettier.format(
             code,

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,40 @@
+const prettier = require("prettier");
+const { readFile, writeFile } = require('@parcel/fs');
+
+async function transformFiles(asset) {
+    let sourceFiles = [asset.name];
+    
+    //Less files need to include deps as well or only the main file is treated (there's probably a better way to do this)
+    if(asset.type === "css")
+        sourceFiles = sourceFiles.concat(Array.from(asset.dependencies, ([key, value]) => value.name));
+        
+    return sourceFiles.forEach(source => prettify(source, asset.encoding));
+}
+
+async function prettify(source, encoding) {
+    if(!source)
+        return;
+
+    let code = await readFile(source, encoding);
+
+    var config = Object.assign({}, await prettier.resolveConfig(source));
+
+    config.filepath = source;
+
+    var prettierSource = prettier.format(
+        code,
+        config
+    );
+
+    if (prettierSource !== code) {
+        new Promise(() => {
+            writeFile(source, prettierSource, encoding, err => {
+                if (err) throw err;
+            });
+        })
+    }
+
+    return code;
+}
+
+module.exports = transformFiles;

--- a/src/common.js
+++ b/src/common.js
@@ -21,10 +21,15 @@ async function prettify(source, encoding) {
 
     config.filepath = source;
 
-    var prettierSource = prettier.format(
-        code,
-        config
-    );
+    try {
+        var prettierSource = await prettier.format(
+            code,
+            config
+        );
+    }
+    catch(err) {
+        //Do nothing
+    }
 
     if (prettierSource !== code) {
         new Promise(() => {

--- a/src/common.js
+++ b/src/common.js
@@ -26,17 +26,17 @@ async function prettify(source, encoding) {
             code,
             config
         );
+
+        if (prettierSource !== code) {
+            new Promise(() => {
+                writeFile(source, prettierSource, encoding, err => {
+                    if (err) throw err;
+                });
+            })
+        }
     }
     catch(err) {
         //Do nothing
-    }
-
-    if (prettierSource !== code) {
-        new Promise(() => {
-            writeFile(source, prettierSource, encoding, err => {
-                if (err) throw err;
-            });
-        })
     }
 
     return code;


### PR DESCRIPTION
I fixed a small bug regarding Prettier : we don't need to give it a parser anymore, just the filename so it can figure it out itself.
With this change, it's also possible to use the same Asset.js structure for every file type instead of having 8 very similar files for each type, but that will be for later as it is working as-is.